### PR TITLE
Depmod is a time consuming process. so we turn up timeout

### DIFF
--- a/pkg/drbd/installer_linux.go
+++ b/pkg/drbd/installer_linux.go
@@ -96,6 +96,7 @@ func (i *DRBDKernelModInstaller) CopyKernelModToHost() error {
 func (i *DRBDKernelModInstaller) Depmod() error {
 	cmd := exechelper.ExecParams{
 		CmdName: "depmod",
+		Timeout: 300,
 	}
 
 	exec := nsexecutor.New()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### Why we need this PR:
```
Depmod is a time consuming process. so we turn up timeout
```
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```
